### PR TITLE
Return the app info in success callback for android

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,9 @@ appAvailability.check(
 ```javascript
 appAvailability.check(
     'com.twitter.android', // Package Name
-    function() {           // Success callback
-        console.log('Twitter is available');
+    function(info) {           // Success callback        
+        // Info parameter is available only for android
+        console.log('Twitter is available, and it\'s version is ', info.version);
     },
     function() {           // Error callback
         console.log('Twitter is not available');

--- a/src/android/AppAvailability.java
+++ b/src/android/AppAvailability.java
@@ -4,9 +4,11 @@ import org.apache.cordova.CallbackContext;
 import org.apache.cordova.CordovaPlugin;
 import org.json.JSONArray;
 import org.json.JSONException;
+import org.json.JSONObject;
 
 import android.content.Context;
 import android.content.pm.PackageManager;
+import android.content.pm.PackageInfo;
 
 public class AppAvailability extends CordovaPlugin {
     @Override
@@ -20,26 +22,40 @@ public class AppAvailability extends CordovaPlugin {
     }
     
     // Thanks to http://floresosvaldo.com/android-cordova-plugin-checking-if-an-app-exists
-    public boolean appInstalled(String uri) {
+    public PackageInfo getAppPackageInfo(String uri) {
         Context ctx = this.cordova.getActivity().getApplicationContext();
         final PackageManager pm = ctx.getPackageManager();
-        boolean app_installed = false;
+
         try {
-            pm.getPackageInfo(uri, PackageManager.GET_ACTIVITIES);
-            app_installed = true;
+            return pm.getPackageInfo(uri, PackageManager.GET_ACTIVITIES);
         }
         catch(PackageManager.NameNotFoundException e) {
-            app_installed = false;
+            return null;
         }
-        return app_installed;
     }
     
     private void checkAvailability(String uri, CallbackContext callbackContext) {
-        if(appInstalled(uri)) {
-            callbackContext.success();
+
+        PackageInfo info = getAppPackageInfo(uri);
+
+        if(info != null) {
+            try {
+                callbackContext.success(this.convertPackageInfoToJson(info));
+            } 
+            catch(JSONException e) {
+                callbackContext.error("");    
+            }
         }
         else {
             callbackContext.error("");
         }
+    }
+
+    private JSONObject convertPackageInfoToJson(PackageInfo info) throws JSONException {
+        JSONObject json = new JSONObject();
+        json.put("version", info.versionName);
+        json.put("appId", info.packageName);
+
+        return json;
     }
 }


### PR DESCRIPTION

I've changed _android success callback_ to return the application info too.
In some cases, only check if the app is available on the platform is not sufficient, because the user can have an outdated version, and that version could not support the *URI scheme* yet.

In my case, I needed to check if the app version is *>"1.8.0"* for example.

This change is only for android due to the _canOpenURL_ from _IOS_ already check if can open the URI scheme.

I hope that it can help someone else.